### PR TITLE
Add YAML tags to config fields

### DIFF
--- a/config.go
+++ b/config.go
@@ -35,17 +35,17 @@ type Config struct {
 	// This field isn't really needed anyway, so we are deprecating it without replacement.
 	// It will be ignored if it is present.
 	// +optional
-	APIVersion string `json:"apiVersion,omitempty"`
+	APIVersion string `json:"apiVersion,omitempty" yaml:"apiVersion"`
 	// Preferences holds general information to be use for cli interactions
 	Preferences Preferences `json:"preferences"`
 	// Clusters is a map of referencable names to cluster configs
 	Clusters []NamedCluster `json:"clusters"`
 	// AuthInfos is a map of referencable names to user configs
-	AuthInfos []NamedAuthInfo `json:"users"`
+	AuthInfos []NamedAuthInfo `json:"users" yaml:"users"`
 	// Contexts is a map of referencable names to context configs
 	Contexts []NamedContext `json:"contexts"`
 	// CurrentContext is the name of the context that you would like to use by default
-	CurrentContext string `json:"current-context"`
+	CurrentContext string `json:"current-context" yaml:"current-context"`
 	// Extensions holds additional information. This is useful for extenders so that reads and writes don't clobber unknown fields
 	// +optional
 	Extensions []NamedExtension `json:"extensions,omitempty"`
@@ -65,16 +65,16 @@ type Cluster struct {
 	Server string `json:"server"`
 	// APIVersion is the preferred api version for communicating with the kubernetes cluster (v1, v2, etc).
 	// +optional
-	APIVersion string `json:"api-version,omitempty"`
+	APIVersion string `json:"api-version,omitempty" yaml:"api-version"`
 	// InsecureSkipTLSVerify skips the validity check for the server's certificate. This will make your HTTPS connections insecure.
 	// +optional
-	InsecureSkipTLSVerify bool `json:"insecure-skip-tls-verify,omitempty"`
+	InsecureSkipTLSVerify bool `json:"insecure-skip-tls-verify,omitempty" yaml:"insecure-skip-tls-verify"`
 	// CertificateAuthority is the path to a cert file for the certificate authority.
 	// +optional
-	CertificateAuthority string `json:"certificate-authority,omitempty"`
+	CertificateAuthority string `json:"certificate-authority,omitempty" yaml:"certificate-authority"`
 	// CertificateAuthorityData contains PEM-encoded certificate authority certificates. Overrides CertificateAuthority
 	// +optional
-	CertificateAuthorityData []byte `json:"certificate-authority-data,omitempty"`
+	CertificateAuthorityData []byte `json:"certificate-authority-data,omitempty" yaml:"certificate-authority-data"`
 	// Extensions holds additional information. This is useful for extenders so that reads and writes don't clobber unknown fields
 	// +optional
 	Extensions []NamedExtension `json:"extensions,omitempty"`
@@ -84,25 +84,25 @@ type Cluster struct {
 type AuthInfo struct {
 	// ClientCertificate is the path to a client cert file for TLS.
 	// +optional
-	ClientCertificate string `json:"client-certificate,omitempty"`
+	ClientCertificate string `json:"client-certificate,omitempty" yaml:"client-certificate"`
 	// ClientCertificateData contains PEM-encoded data from a client cert file for TLS. Overrides ClientCertificate
 	// +optional
-	ClientCertificateData []byte `json:"client-certificate-data,omitempty"`
+	ClientCertificateData []byte `json:"client-certificate-data,omitempty" yaml:"client-certificate-data,omitempty"`
 	// ClientKey is the path to a client key file for TLS.
 	// +optional
-	ClientKey string `json:"client-key,omitempty"`
+	ClientKey string `json:"client-key,omitempty" yaml:"client-key"`
 	// ClientKeyData contains PEM-encoded data from a client key file for TLS. Overrides ClientKey
 	// +optional
-	ClientKeyData []byte `json:"client-key-data,omitempty"`
+	ClientKeyData []byte `json:"client-key-data,omitempty" yaml:"client-key-data,omitempty"`
 	// Token is the bearer token for authentication to the kubernetes cluster.
 	// +optional
 	Token string `json:"token,omitempty"`
 	// TokenFile is a pointer to a file that contains a bearer token (as described above).  If both Token and TokenFile are present, Token takes precedence.
 	// +optional
-	TokenFile string `json:"tokenFile,omitempty"`
+	TokenFile string `json:"tokenFile,omitempty" yaml:"tokenFile"`
 	// Impersonate is the username to imperonate.  The name matches the flag.
 	// +optional
-	Impersonate string `json:"as,omitempty"`
+	Impersonate string `json:"as,omitempty" yaml:"as"`
 	// Username is the username for basic authentication to the kubernetes cluster.
 	// +optional
 	Username string `json:"username,omitempty"`
@@ -111,7 +111,7 @@ type AuthInfo struct {
 	Password string `json:"password,omitempty"`
 	// AuthProvider specifies a custom authentication plugin for the kubernetes cluster.
 	// +optional
-	AuthProvider *AuthProviderConfig `json:"auth-provider,omitempty"`
+	AuthProvider *AuthProviderConfig `json:"auth-provider,omitempty" yaml:"auth-provider"`
 	// Extensions holds additional information. This is useful for extenders so that reads and writes don't clobber unknown fields
 	// +optional
 	Extensions []NamedExtension `json:"extensions,omitempty"`
@@ -122,7 +122,7 @@ type Context struct {
 	// Cluster is the name of the cluster for this context
 	Cluster string `json:"cluster"`
 	// AuthInfo is the name of the authInfo for this context
-	AuthInfo string `json:"user"`
+	AuthInfo string `json:"user" yaml:"user"`
 	// Namespace is the default namespace to use on unspecified requests
 	// +optional
 	Namespace string `json:"namespace,omitempty"`
@@ -152,7 +152,7 @@ type NamedAuthInfo struct {
 	// Name is the nickname for this AuthInfo
 	Name string `json:"name"`
 	// AuthInfo holds the auth information
-	AuthInfo AuthInfo `json:"user"`
+	AuthInfo AuthInfo `json:"user" yaml:"user"`
 }
 
 // NamedExtension relates nicknames to extension information


### PR DESCRIPTION
I've found that client settings written in YAML are not correctly parsed. For example, minikube:

```
apiVersion: v1
clusters:
- cluster:
    certificate-authority: /home/exekias/.minikube/ca.crt
    server: https://192.168.99.100:8443
  name: minikube
contexts:
- context:
    cluster: minikube
    user: minikube
  name: minikube
current-context: minikube
kind: Config
preferences: {}
users:
- name: minikube
  user:
    client-certificate: /home/exekias/.minikube/apiserver.crt
    client-key: /home/exekias/.minikube/apiserver.key
```

I just added yaml tag to fields that use a different name from the spec