### PR TITLE
LabelSelector should support / chars in keys

### DIFF
--- a/labels.go
+++ b/labels.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	qnameCharFmt           string = "[A-Za-z0-9]"
-	qnameExtCharFmt        string = "[-A-Za-z0-9_.]"
+	qnameExtCharFmt        string = "[-A-Za-z0-9_./]"
 	qualifiedNameFmt       string = "(" + qnameCharFmt + qnameExtCharFmt + "*)?" + qnameCharFmt
 	qualifiedNameMaxLength int    = 63
 	labelValueFmt          string = "(" + qualifiedNameFmt + ")?"

--- a/labels_test.go
+++ b/labels_test.go
@@ -15,6 +15,12 @@ func TestLabelSelector(t *testing.T) {
 		},
 		{
 			f: func(l *LabelSelector) {
+				l.Eq("kubernetes.io/role", "master")
+			},
+			want: "kubernetes.io/role=master",
+		},
+		{
+			f: func(l *LabelSelector) {
 				l.In("type", "prod", "staging")
 				l.Eq("component", "frontend")
 			},


### PR DESCRIPTION
Kubernetes uses / characters in its applied labels, for example the
label applied to a node to determine whether it is a node or master.
This library should support using this character in a key name.