### PR TITLE
Pass context.Context to net/http client

### DIFF
--- a/client.go
+++ b/client.go
@@ -107,7 +107,7 @@ type Client struct {
 	Client *http.Client
 }
 
-func (c *Client) newRequest(verb, url string, body io.Reader) (*http.Request, error) {
+func (c *Client) newRequest(ctx context.Context, verb, url string, body io.Reader) (*http.Request, error) {
 	req, err := http.NewRequest(verb, url, body)
 	if err != nil {
 		return nil, err
@@ -117,7 +117,7 @@ func (c *Client) newRequest(verb, url string, body io.Reader) (*http.Request, er
 			return nil, err
 		}
 	}
-	return req, nil
+	return req.WithContext(ctx), nil
 }
 
 // Option represents optional call parameters, such as label selectors.
@@ -438,7 +438,7 @@ func (c *Client) create(ctx context.Context, codec *codec, verb, url string, req
 		return err
 	}
 
-	r, err := c.newRequest(verb, url, bytes.NewReader(body))
+	r, err := c.newRequest(ctx, verb, url, bytes.NewReader(body))
 	if err != nil {
 		return err
 	}
@@ -463,7 +463,7 @@ func (c *Client) create(ctx context.Context, codec *codec, verb, url string, req
 }
 
 func (c *Client) delete(ctx context.Context, codec *codec, url string) error {
-	r, err := c.newRequest("DELETE", url, nil)
+	r, err := c.newRequest(ctx, "DELETE", url, nil)
 	if err != nil {
 		return err
 	}
@@ -488,7 +488,7 @@ func (c *Client) delete(ctx context.Context, codec *codec, url string) error {
 
 // get can be used to either get or list a given resource.
 func (c *Client) get(ctx context.Context, codec *codec, url string, resp interface{}) error {
-	r, err := c.newRequest("GET", url, nil)
+	r, err := c.newRequest(ctx, "GET", url, nil)
 	if err != nil {
 		return err
 	}
@@ -574,7 +574,7 @@ func (c *Client) watch(ctx context.Context, url string) (*watcher, error) {
 	} else {
 		url = url + "?watch=true"
 	}
-	r, err := c.newRequest("GET", url, nil)
+	r, err := c.newRequest(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This change creates the `http.Request` using `WithContext`- allowing clients to control timeouts/cancellations etc.