### PR TITLE
add watcher to thirdpartyresource, make code for watcher configurable

### DIFF
--- a/client.go
+++ b/client.go
@@ -614,7 +614,7 @@ func (c *Client) watch(ctx context.Context, codec *codec, url string) (*watcher,
 		if err != nil {
 			return nil, err
 		}
-		return nil, newAPIError(pbCodec, resp.StatusCode, body)
+		return nil, newAPIError(codec, resp.StatusCode, body)
 	}
 
 	w := &watcher{resp.Body, codec}

--- a/tprs.go
+++ b/tprs.go
@@ -2,10 +2,12 @@ package k8s
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 
 	"github.com/ericchiang/k8s/api/v1"
 	metav1 "github.com/ericchiang/k8s/apis/meta/v1"
+	"github.com/ericchiang/k8s/watch/versioned"
 )
 
 // ThirdPartyResources is a client used for interacting with user
@@ -163,4 +165,35 @@ func (t *ThirdPartyResources) List(ctx context.Context, resource, namespace stri
 	}
 	url := t.c.urlFor(t.apiGroup, t.apiVersion, namespace, resource, "")
 	return t.c.get(ctx, jsonCodec, url, resp)
+}
+
+type ThirdPartyResourcesWatcher struct {
+	watcher *watcher
+}
+
+func (w *ThirdPartyResourcesWatcher) Next(resp interface{}) (*versioned.Event, error) {
+	event, unknown, err := w.watcher.next()
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(unknown.Raw, resp); err != nil {
+		return nil, err
+	}
+	return event, nil
+}
+
+func (w *ThirdPartyResourcesWatcher) Close() error {
+	return w.watcher.Close()
+}
+
+func (t *ThirdPartyResources) Watch(ctx context.Context, resource, namespace string, options ...Option) (*ThirdPartyResourcesWatcher, error) {
+	if err := checkResource(t.apiGroup, t.apiVersion, resource, namespace, "name not required"); err != nil {
+		return nil, err
+	}
+	url := t.c.urlFor(t.apiGroup, t.apiVersion, namespace, resource, "", options...)
+	watcher, err := t.c.watch(ctx, jsonCodec, url)
+	if err != nil {
+		return nil, err
+	}
+	return &ThirdPartyResourcesWatcher{watcher}, nil
 }

--- a/types.go
+++ b/types.go
@@ -50,7 +50,7 @@ func (c *CoreV1) CreateBinding(ctx context.Context, obj *apiv1.Binding) (*apiv1.
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -128,7 +128,7 @@ func (c *CoreV1) CreateComponentStatus(ctx context.Context, obj *apiv1.Component
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !false && ns != ""{
+	if !false && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -218,7 +218,7 @@ func (w *CoreV1ComponentStatusWatcher) Close() error {
 
 func (c *CoreV1) WatchComponentStatuses(ctx context.Context, options ...Option) (*CoreV1ComponentStatusWatcher, error) {
 	url := c.client.urlFor("", "v1", AllNamespaces, "componentstatuses", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -244,7 +244,7 @@ func (c *CoreV1) CreateConfigMap(ctx context.Context, obj *apiv1.ConfigMap) (*ap
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -334,7 +334,7 @@ func (w *CoreV1ConfigMapWatcher) Close() error {
 
 func (c *CoreV1) WatchConfigMaps(ctx context.Context, namespace string, options ...Option) (*CoreV1ConfigMapWatcher, error) {
 	url := c.client.urlFor("", "v1", namespace, "configmaps", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -360,7 +360,7 @@ func (c *CoreV1) CreateEndpoints(ctx context.Context, obj *apiv1.Endpoints) (*ap
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -450,7 +450,7 @@ func (w *CoreV1EndpointsWatcher) Close() error {
 
 func (c *CoreV1) WatchEndpoints(ctx context.Context, namespace string, options ...Option) (*CoreV1EndpointsWatcher, error) {
 	url := c.client.urlFor("", "v1", namespace, "endpoints", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -476,7 +476,7 @@ func (c *CoreV1) CreateEvent(ctx context.Context, obj *apiv1.Event) (*apiv1.Even
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -566,7 +566,7 @@ func (w *CoreV1EventWatcher) Close() error {
 
 func (c *CoreV1) WatchEvents(ctx context.Context, namespace string, options ...Option) (*CoreV1EventWatcher, error) {
 	url := c.client.urlFor("", "v1", namespace, "events", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -592,7 +592,7 @@ func (c *CoreV1) CreateLimitRange(ctx context.Context, obj *apiv1.LimitRange) (*
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -682,7 +682,7 @@ func (w *CoreV1LimitRangeWatcher) Close() error {
 
 func (c *CoreV1) WatchLimitRanges(ctx context.Context, namespace string, options ...Option) (*CoreV1LimitRangeWatcher, error) {
 	url := c.client.urlFor("", "v1", namespace, "limitranges", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -708,7 +708,7 @@ func (c *CoreV1) CreateNamespace(ctx context.Context, obj *apiv1.Namespace) (*ap
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !false && ns != ""{
+	if !false && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -798,7 +798,7 @@ func (w *CoreV1NamespaceWatcher) Close() error {
 
 func (c *CoreV1) WatchNamespaces(ctx context.Context, options ...Option) (*CoreV1NamespaceWatcher, error) {
 	url := c.client.urlFor("", "v1", AllNamespaces, "namespaces", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -824,7 +824,7 @@ func (c *CoreV1) CreateNode(ctx context.Context, obj *apiv1.Node) (*apiv1.Node, 
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !false && ns != ""{
+	if !false && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -914,7 +914,7 @@ func (w *CoreV1NodeWatcher) Close() error {
 
 func (c *CoreV1) WatchNodes(ctx context.Context, options ...Option) (*CoreV1NodeWatcher, error) {
 	url := c.client.urlFor("", "v1", AllNamespaces, "nodes", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -940,7 +940,7 @@ func (c *CoreV1) CreatePersistentVolume(ctx context.Context, obj *apiv1.Persiste
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !false && ns != ""{
+	if !false && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -1030,7 +1030,7 @@ func (w *CoreV1PersistentVolumeWatcher) Close() error {
 
 func (c *CoreV1) WatchPersistentVolumes(ctx context.Context, options ...Option) (*CoreV1PersistentVolumeWatcher, error) {
 	url := c.client.urlFor("", "v1", AllNamespaces, "persistentvolumes", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -1056,7 +1056,7 @@ func (c *CoreV1) CreatePersistentVolumeClaim(ctx context.Context, obj *apiv1.Per
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -1146,7 +1146,7 @@ func (w *CoreV1PersistentVolumeClaimWatcher) Close() error {
 
 func (c *CoreV1) WatchPersistentVolumeClaims(ctx context.Context, namespace string, options ...Option) (*CoreV1PersistentVolumeClaimWatcher, error) {
 	url := c.client.urlFor("", "v1", namespace, "persistentvolumeclaims", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -1172,7 +1172,7 @@ func (c *CoreV1) CreatePod(ctx context.Context, obj *apiv1.Pod) (*apiv1.Pod, err
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -1262,7 +1262,7 @@ func (w *CoreV1PodWatcher) Close() error {
 
 func (c *CoreV1) WatchPods(ctx context.Context, namespace string, options ...Option) (*CoreV1PodWatcher, error) {
 	url := c.client.urlFor("", "v1", namespace, "pods", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -1288,7 +1288,7 @@ func (c *CoreV1) CreatePodStatusResult(ctx context.Context, obj *apiv1.PodStatus
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -1366,7 +1366,7 @@ func (c *CoreV1) CreatePodTemplate(ctx context.Context, obj *apiv1.PodTemplate) 
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -1456,7 +1456,7 @@ func (w *CoreV1PodTemplateWatcher) Close() error {
 
 func (c *CoreV1) WatchPodTemplates(ctx context.Context, namespace string, options ...Option) (*CoreV1PodTemplateWatcher, error) {
 	url := c.client.urlFor("", "v1", namespace, "podtemplates", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -1482,7 +1482,7 @@ func (c *CoreV1) CreatePodTemplateSpec(ctx context.Context, obj *apiv1.PodTempla
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -1560,7 +1560,7 @@ func (c *CoreV1) CreateRangeAllocation(ctx context.Context, obj *apiv1.RangeAllo
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -1638,7 +1638,7 @@ func (c *CoreV1) CreateReplicationController(ctx context.Context, obj *apiv1.Rep
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -1728,7 +1728,7 @@ func (w *CoreV1ReplicationControllerWatcher) Close() error {
 
 func (c *CoreV1) WatchReplicationControllers(ctx context.Context, namespace string, options ...Option) (*CoreV1ReplicationControllerWatcher, error) {
 	url := c.client.urlFor("", "v1", namespace, "replicationcontrollers", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -1754,7 +1754,7 @@ func (c *CoreV1) CreateResourceQuota(ctx context.Context, obj *apiv1.ResourceQuo
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -1844,7 +1844,7 @@ func (w *CoreV1ResourceQuotaWatcher) Close() error {
 
 func (c *CoreV1) WatchResourceQuotas(ctx context.Context, namespace string, options ...Option) (*CoreV1ResourceQuotaWatcher, error) {
 	url := c.client.urlFor("", "v1", namespace, "resourcequotas", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -1870,7 +1870,7 @@ func (c *CoreV1) CreateSecret(ctx context.Context, obj *apiv1.Secret) (*apiv1.Se
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -1960,7 +1960,7 @@ func (w *CoreV1SecretWatcher) Close() error {
 
 func (c *CoreV1) WatchSecrets(ctx context.Context, namespace string, options ...Option) (*CoreV1SecretWatcher, error) {
 	url := c.client.urlFor("", "v1", namespace, "secrets", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -1986,7 +1986,7 @@ func (c *CoreV1) CreateService(ctx context.Context, obj *apiv1.Service) (*apiv1.
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -2076,7 +2076,7 @@ func (w *CoreV1ServiceWatcher) Close() error {
 
 func (c *CoreV1) WatchServices(ctx context.Context, namespace string, options ...Option) (*CoreV1ServiceWatcher, error) {
 	url := c.client.urlFor("", "v1", namespace, "services", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -2102,7 +2102,7 @@ func (c *CoreV1) CreateServiceAccount(ctx context.Context, obj *apiv1.ServiceAcc
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -2192,7 +2192,7 @@ func (w *CoreV1ServiceAccountWatcher) Close() error {
 
 func (c *CoreV1) WatchServiceAccounts(ctx context.Context, namespace string, options ...Option) (*CoreV1ServiceAccountWatcher, error) {
 	url := c.client.urlFor("", "v1", namespace, "serviceaccounts", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -2207,7 +2207,6 @@ func (c *CoreV1) ListServiceAccounts(ctx context.Context, namespace string, opti
 	}
 	return resp, nil
 }
-
 
 // AppsV1Alpha1 returns a client for interacting with the apps/v1alpha1 API group.
 func (c *Client) AppsV1Alpha1() *AppsV1Alpha1 {
@@ -2229,7 +2228,7 @@ func (c *AppsV1Alpha1) CreatePetSet(ctx context.Context, obj *appsv1alpha1.PetSe
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -2319,7 +2318,7 @@ func (w *AppsV1Alpha1PetSetWatcher) Close() error {
 
 func (c *AppsV1Alpha1) WatchPetSets(ctx context.Context, namespace string, options ...Option) (*AppsV1Alpha1PetSetWatcher, error) {
 	url := c.client.urlFor("apps", "v1alpha1", namespace, "petsets", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -2334,7 +2333,6 @@ func (c *AppsV1Alpha1) ListPetSets(ctx context.Context, namespace string, option
 	}
 	return resp, nil
 }
-
 
 // AppsV1Beta1 returns a client for interacting with the apps/v1beta1 API group.
 func (c *Client) AppsV1Beta1() *AppsV1Beta1 {
@@ -2356,7 +2354,7 @@ func (c *AppsV1Beta1) CreateDeployment(ctx context.Context, obj *appsv1beta1.Dep
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -2446,7 +2444,7 @@ func (w *AppsV1Beta1DeploymentWatcher) Close() error {
 
 func (c *AppsV1Beta1) WatchDeployments(ctx context.Context, namespace string, options ...Option) (*AppsV1Beta1DeploymentWatcher, error) {
 	url := c.client.urlFor("apps", "v1beta1", namespace, "deployments", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -2472,7 +2470,7 @@ func (c *AppsV1Beta1) CreateScale(ctx context.Context, obj *appsv1beta1.Scale) (
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -2550,7 +2548,7 @@ func (c *AppsV1Beta1) CreateStatefulSet(ctx context.Context, obj *appsv1beta1.St
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -2640,7 +2638,7 @@ func (w *AppsV1Beta1StatefulSetWatcher) Close() error {
 
 func (c *AppsV1Beta1) WatchStatefulSets(ctx context.Context, namespace string, options ...Option) (*AppsV1Beta1StatefulSetWatcher, error) {
 	url := c.client.urlFor("apps", "v1beta1", namespace, "statefulsets", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -2655,7 +2653,6 @@ func (c *AppsV1Beta1) ListStatefulSets(ctx context.Context, namespace string, op
 	}
 	return resp, nil
 }
-
 
 // AuthenticationV1 returns a client for interacting with the authentication.k8s.io/v1 API group.
 func (c *Client) AuthenticationV1() *AuthenticationV1 {
@@ -2677,7 +2674,7 @@ func (c *AuthenticationV1) CreateTokenReview(ctx context.Context, obj *authentic
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !false && ns != ""{
+	if !false && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -2745,7 +2742,6 @@ func (c *AuthenticationV1) GetTokenReview(ctx context.Context, name string) (*au
 	return resp, nil
 }
 
-
 // AuthenticationV1Beta1 returns a client for interacting with the authentication.k8s.io/v1beta1 API group.
 func (c *Client) AuthenticationV1Beta1() *AuthenticationV1Beta1 {
 	return &AuthenticationV1Beta1{c}
@@ -2766,7 +2762,7 @@ func (c *AuthenticationV1Beta1) CreateTokenReview(ctx context.Context, obj *auth
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !false && ns != ""{
+	if !false && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -2834,7 +2830,6 @@ func (c *AuthenticationV1Beta1) GetTokenReview(ctx context.Context, name string)
 	return resp, nil
 }
 
-
 // AuthorizationV1 returns a client for interacting with the authorization.k8s.io/v1 API group.
 func (c *Client) AuthorizationV1() *AuthorizationV1 {
 	return &AuthorizationV1{c}
@@ -2855,7 +2850,7 @@ func (c *AuthorizationV1) CreateLocalSubjectAccessReview(ctx context.Context, ob
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -2933,7 +2928,7 @@ func (c *AuthorizationV1) CreateSelfSubjectAccessReview(ctx context.Context, obj
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !false && ns != ""{
+	if !false && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -3011,7 +3006,7 @@ func (c *AuthorizationV1) CreateSubjectAccessReview(ctx context.Context, obj *au
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !false && ns != ""{
+	if !false && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -3079,7 +3074,6 @@ func (c *AuthorizationV1) GetSubjectAccessReview(ctx context.Context, name strin
 	return resp, nil
 }
 
-
 // AuthorizationV1Beta1 returns a client for interacting with the authorization.k8s.io/v1beta1 API group.
 func (c *Client) AuthorizationV1Beta1() *AuthorizationV1Beta1 {
 	return &AuthorizationV1Beta1{c}
@@ -3100,7 +3094,7 @@ func (c *AuthorizationV1Beta1) CreateLocalSubjectAccessReview(ctx context.Contex
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -3178,7 +3172,7 @@ func (c *AuthorizationV1Beta1) CreateSelfSubjectAccessReview(ctx context.Context
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !false && ns != ""{
+	if !false && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -3256,7 +3250,7 @@ func (c *AuthorizationV1Beta1) CreateSubjectAccessReview(ctx context.Context, ob
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !false && ns != ""{
+	if !false && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -3324,7 +3318,6 @@ func (c *AuthorizationV1Beta1) GetSubjectAccessReview(ctx context.Context, name 
 	return resp, nil
 }
 
-
 // AutoscalingV1 returns a client for interacting with the autoscaling/v1 API group.
 func (c *Client) AutoscalingV1() *AutoscalingV1 {
 	return &AutoscalingV1{c}
@@ -3345,7 +3338,7 @@ func (c *AutoscalingV1) CreateHorizontalPodAutoscaler(ctx context.Context, obj *
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -3435,7 +3428,7 @@ func (w *AutoscalingV1HorizontalPodAutoscalerWatcher) Close() error {
 
 func (c *AutoscalingV1) WatchHorizontalPodAutoscalers(ctx context.Context, namespace string, options ...Option) (*AutoscalingV1HorizontalPodAutoscalerWatcher, error) {
 	url := c.client.urlFor("autoscaling", "v1", namespace, "horizontalpodautoscalers", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -3461,7 +3454,7 @@ func (c *AutoscalingV1) CreateScale(ctx context.Context, obj *autoscalingv1.Scal
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -3529,7 +3522,6 @@ func (c *AutoscalingV1) GetScale(ctx context.Context, name, namespace string) (*
 	return resp, nil
 }
 
-
 // AutoscalingV2Alpha1 returns a client for interacting with the autoscaling/v2alpha1 API group.
 func (c *Client) AutoscalingV2Alpha1() *AutoscalingV2Alpha1 {
 	return &AutoscalingV2Alpha1{c}
@@ -3550,7 +3542,7 @@ func (c *AutoscalingV2Alpha1) CreateHorizontalPodAutoscaler(ctx context.Context,
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -3640,7 +3632,7 @@ func (w *AutoscalingV2Alpha1HorizontalPodAutoscalerWatcher) Close() error {
 
 func (c *AutoscalingV2Alpha1) WatchHorizontalPodAutoscalers(ctx context.Context, namespace string, options ...Option) (*AutoscalingV2Alpha1HorizontalPodAutoscalerWatcher, error) {
 	url := c.client.urlFor("autoscaling", "v2alpha1", namespace, "horizontalpodautoscalers", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -3655,7 +3647,6 @@ func (c *AutoscalingV2Alpha1) ListHorizontalPodAutoscalers(ctx context.Context, 
 	}
 	return resp, nil
 }
-
 
 // BatchV1 returns a client for interacting with the batch/v1 API group.
 func (c *Client) BatchV1() *BatchV1 {
@@ -3677,7 +3668,7 @@ func (c *BatchV1) CreateJob(ctx context.Context, obj *batchv1.Job) (*batchv1.Job
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -3767,7 +3758,7 @@ func (w *BatchV1JobWatcher) Close() error {
 
 func (c *BatchV1) WatchJobs(ctx context.Context, namespace string, options ...Option) (*BatchV1JobWatcher, error) {
 	url := c.client.urlFor("batch", "v1", namespace, "jobs", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -3782,7 +3773,6 @@ func (c *BatchV1) ListJobs(ctx context.Context, namespace string, options ...Opt
 	}
 	return resp, nil
 }
-
 
 // BatchV2Alpha1 returns a client for interacting with the batch/v2alpha1 API group.
 func (c *Client) BatchV2Alpha1() *BatchV2Alpha1 {
@@ -3804,7 +3794,7 @@ func (c *BatchV2Alpha1) CreateCronJob(ctx context.Context, obj *batchv2alpha1.Cr
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -3894,7 +3884,7 @@ func (w *BatchV2Alpha1CronJobWatcher) Close() error {
 
 func (c *BatchV2Alpha1) WatchCronJobs(ctx context.Context, namespace string, options ...Option) (*BatchV2Alpha1CronJobWatcher, error) {
 	url := c.client.urlFor("batch", "v2alpha1", namespace, "cronjobs", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -3920,7 +3910,7 @@ func (c *BatchV2Alpha1) CreateJobTemplate(ctx context.Context, obj *batchv2alpha
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -3988,7 +3978,6 @@ func (c *BatchV2Alpha1) GetJobTemplate(ctx context.Context, name, namespace stri
 	return resp, nil
 }
 
-
 // CertificatesV1Alpha1 returns a client for interacting with the certificates.k8s.io/v1alpha1 API group.
 func (c *Client) CertificatesV1Alpha1() *CertificatesV1Alpha1 {
 	return &CertificatesV1Alpha1{c}
@@ -4009,7 +3998,7 @@ func (c *CertificatesV1Alpha1) CreateCertificateSigningRequest(ctx context.Conte
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !false && ns != ""{
+	if !false && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -4099,7 +4088,7 @@ func (w *CertificatesV1Alpha1CertificateSigningRequestWatcher) Close() error {
 
 func (c *CertificatesV1Alpha1) WatchCertificateSigningRequests(ctx context.Context, options ...Option) (*CertificatesV1Alpha1CertificateSigningRequestWatcher, error) {
 	url := c.client.urlFor("certificates.k8s.io", "v1alpha1", AllNamespaces, "certificatesigningrequests", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -4114,7 +4103,6 @@ func (c *CertificatesV1Alpha1) ListCertificateSigningRequests(ctx context.Contex
 	}
 	return resp, nil
 }
-
 
 // CertificatesV1Beta1 returns a client for interacting with the certificates.k8s.io/v1beta1 API group.
 func (c *Client) CertificatesV1Beta1() *CertificatesV1Beta1 {
@@ -4136,7 +4124,7 @@ func (c *CertificatesV1Beta1) CreateCertificateSigningRequest(ctx context.Contex
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !false && ns != ""{
+	if !false && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -4226,7 +4214,7 @@ func (w *CertificatesV1Beta1CertificateSigningRequestWatcher) Close() error {
 
 func (c *CertificatesV1Beta1) WatchCertificateSigningRequests(ctx context.Context, options ...Option) (*CertificatesV1Beta1CertificateSigningRequestWatcher, error) {
 	url := c.client.urlFor("certificates.k8s.io", "v1beta1", AllNamespaces, "certificatesigningrequests", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -4241,7 +4229,6 @@ func (c *CertificatesV1Beta1) ListCertificateSigningRequests(ctx context.Context
 	}
 	return resp, nil
 }
-
 
 // ExtensionsV1Beta1 returns a client for interacting with the extensions/v1beta1 API group.
 func (c *Client) ExtensionsV1Beta1() *ExtensionsV1Beta1 {
@@ -4263,7 +4250,7 @@ func (c *ExtensionsV1Beta1) CreateDaemonSet(ctx context.Context, obj *extensions
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -4353,7 +4340,7 @@ func (w *ExtensionsV1Beta1DaemonSetWatcher) Close() error {
 
 func (c *ExtensionsV1Beta1) WatchDaemonSets(ctx context.Context, namespace string, options ...Option) (*ExtensionsV1Beta1DaemonSetWatcher, error) {
 	url := c.client.urlFor("extensions", "v1beta1", namespace, "daemonsets", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -4379,7 +4366,7 @@ func (c *ExtensionsV1Beta1) CreateDeployment(ctx context.Context, obj *extension
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -4469,7 +4456,7 @@ func (w *ExtensionsV1Beta1DeploymentWatcher) Close() error {
 
 func (c *ExtensionsV1Beta1) WatchDeployments(ctx context.Context, namespace string, options ...Option) (*ExtensionsV1Beta1DeploymentWatcher, error) {
 	url := c.client.urlFor("extensions", "v1beta1", namespace, "deployments", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -4495,7 +4482,7 @@ func (c *ExtensionsV1Beta1) CreateIngress(ctx context.Context, obj *extensionsv1
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -4585,7 +4572,7 @@ func (w *ExtensionsV1Beta1IngressWatcher) Close() error {
 
 func (c *ExtensionsV1Beta1) WatchIngresses(ctx context.Context, namespace string, options ...Option) (*ExtensionsV1Beta1IngressWatcher, error) {
 	url := c.client.urlFor("extensions", "v1beta1", namespace, "ingresses", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -4611,7 +4598,7 @@ func (c *ExtensionsV1Beta1) CreateNetworkPolicy(ctx context.Context, obj *extens
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -4701,7 +4688,7 @@ func (w *ExtensionsV1Beta1NetworkPolicyWatcher) Close() error {
 
 func (c *ExtensionsV1Beta1) WatchNetworkPolicies(ctx context.Context, namespace string, options ...Option) (*ExtensionsV1Beta1NetworkPolicyWatcher, error) {
 	url := c.client.urlFor("extensions", "v1beta1", namespace, "networkpolicies", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -4727,7 +4714,7 @@ func (c *ExtensionsV1Beta1) CreatePodSecurityPolicy(ctx context.Context, obj *ex
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !false && ns != ""{
+	if !false && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -4817,7 +4804,7 @@ func (w *ExtensionsV1Beta1PodSecurityPolicyWatcher) Close() error {
 
 func (c *ExtensionsV1Beta1) WatchPodSecurityPolicies(ctx context.Context, options ...Option) (*ExtensionsV1Beta1PodSecurityPolicyWatcher, error) {
 	url := c.client.urlFor("extensions", "v1beta1", AllNamespaces, "podsecuritypolicies", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -4843,7 +4830,7 @@ func (c *ExtensionsV1Beta1) CreateReplicaSet(ctx context.Context, obj *extension
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -4933,7 +4920,7 @@ func (w *ExtensionsV1Beta1ReplicaSetWatcher) Close() error {
 
 func (c *ExtensionsV1Beta1) WatchReplicaSets(ctx context.Context, namespace string, options ...Option) (*ExtensionsV1Beta1ReplicaSetWatcher, error) {
 	url := c.client.urlFor("extensions", "v1beta1", namespace, "replicasets", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -4959,7 +4946,7 @@ func (c *ExtensionsV1Beta1) CreateScale(ctx context.Context, obj *extensionsv1be
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -5037,7 +5024,7 @@ func (c *ExtensionsV1Beta1) CreateThirdPartyResource(ctx context.Context, obj *e
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !false && ns != ""{
+	if !false && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -5127,7 +5114,7 @@ func (w *ExtensionsV1Beta1ThirdPartyResourceWatcher) Close() error {
 
 func (c *ExtensionsV1Beta1) WatchThirdPartyResources(ctx context.Context, options ...Option) (*ExtensionsV1Beta1ThirdPartyResourceWatcher, error) {
 	url := c.client.urlFor("extensions", "v1beta1", AllNamespaces, "thirdpartyresources", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -5153,7 +5140,7 @@ func (c *ExtensionsV1Beta1) CreateThirdPartyResourceData(ctx context.Context, ob
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -5243,7 +5230,7 @@ func (w *ExtensionsV1Beta1ThirdPartyResourceDataWatcher) Close() error {
 
 func (c *ExtensionsV1Beta1) WatchThirdPartyResourceDatas(ctx context.Context, namespace string, options ...Option) (*ExtensionsV1Beta1ThirdPartyResourceDataWatcher, error) {
 	url := c.client.urlFor("extensions", "v1beta1", namespace, "thirdpartyresourcedatas", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -5258,7 +5245,6 @@ func (c *ExtensionsV1Beta1) ListThirdPartyResourceDatas(ctx context.Context, nam
 	}
 	return resp, nil
 }
-
 
 // ImagepolicyV1Alpha1 returns a client for interacting with the imagepolicy/v1alpha1 API group.
 func (c *Client) ImagepolicyV1Alpha1() *ImagepolicyV1Alpha1 {
@@ -5280,7 +5266,7 @@ func (c *ImagepolicyV1Alpha1) CreateImageReview(ctx context.Context, obj *imagep
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !false && ns != ""{
+	if !false && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -5348,7 +5334,6 @@ func (c *ImagepolicyV1Alpha1) GetImageReview(ctx context.Context, name string) (
 	return resp, nil
 }
 
-
 // PolicyV1Alpha1 returns a client for interacting with the policy/v1alpha1 API group.
 func (c *Client) PolicyV1Alpha1() *PolicyV1Alpha1 {
 	return &PolicyV1Alpha1{c}
@@ -5369,7 +5354,7 @@ func (c *PolicyV1Alpha1) CreateEviction(ctx context.Context, obj *policyv1alpha1
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -5447,7 +5432,7 @@ func (c *PolicyV1Alpha1) CreatePodDisruptionBudget(ctx context.Context, obj *pol
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -5537,7 +5522,7 @@ func (w *PolicyV1Alpha1PodDisruptionBudgetWatcher) Close() error {
 
 func (c *PolicyV1Alpha1) WatchPodDisruptionBudgets(ctx context.Context, namespace string, options ...Option) (*PolicyV1Alpha1PodDisruptionBudgetWatcher, error) {
 	url := c.client.urlFor("policy", "v1alpha1", namespace, "poddisruptionbudgets", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -5552,7 +5537,6 @@ func (c *PolicyV1Alpha1) ListPodDisruptionBudgets(ctx context.Context, namespace
 	}
 	return resp, nil
 }
-
 
 // PolicyV1Beta1 returns a client for interacting with the policy/v1beta1 API group.
 func (c *Client) PolicyV1Beta1() *PolicyV1Beta1 {
@@ -5574,7 +5558,7 @@ func (c *PolicyV1Beta1) CreateEviction(ctx context.Context, obj *policyv1beta1.E
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -5652,7 +5636,7 @@ func (c *PolicyV1Beta1) CreatePodDisruptionBudget(ctx context.Context, obj *poli
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -5742,7 +5726,7 @@ func (w *PolicyV1Beta1PodDisruptionBudgetWatcher) Close() error {
 
 func (c *PolicyV1Beta1) WatchPodDisruptionBudgets(ctx context.Context, namespace string, options ...Option) (*PolicyV1Beta1PodDisruptionBudgetWatcher, error) {
 	url := c.client.urlFor("policy", "v1beta1", namespace, "poddisruptionbudgets", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -5757,7 +5741,6 @@ func (c *PolicyV1Beta1) ListPodDisruptionBudgets(ctx context.Context, namespace 
 	}
 	return resp, nil
 }
-
 
 // RBACV1Alpha1 returns a client for interacting with the rbac.authorization.k8s.io/v1alpha1 API group.
 func (c *Client) RBACV1Alpha1() *RBACV1Alpha1 {
@@ -5779,7 +5762,7 @@ func (c *RBACV1Alpha1) CreateClusterRole(ctx context.Context, obj *rbacv1alpha1.
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !false && ns != ""{
+	if !false && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -5869,7 +5852,7 @@ func (w *RBACV1Alpha1ClusterRoleWatcher) Close() error {
 
 func (c *RBACV1Alpha1) WatchClusterRoles(ctx context.Context, options ...Option) (*RBACV1Alpha1ClusterRoleWatcher, error) {
 	url := c.client.urlFor("rbac.authorization.k8s.io", "v1alpha1", AllNamespaces, "clusterroles", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -5895,7 +5878,7 @@ func (c *RBACV1Alpha1) CreateClusterRoleBinding(ctx context.Context, obj *rbacv1
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !false && ns != ""{
+	if !false && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -5985,7 +5968,7 @@ func (w *RBACV1Alpha1ClusterRoleBindingWatcher) Close() error {
 
 func (c *RBACV1Alpha1) WatchClusterRoleBindings(ctx context.Context, options ...Option) (*RBACV1Alpha1ClusterRoleBindingWatcher, error) {
 	url := c.client.urlFor("rbac.authorization.k8s.io", "v1alpha1", AllNamespaces, "clusterrolebindings", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -6011,7 +5994,7 @@ func (c *RBACV1Alpha1) CreateRole(ctx context.Context, obj *rbacv1alpha1.Role) (
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -6101,7 +6084,7 @@ func (w *RBACV1Alpha1RoleWatcher) Close() error {
 
 func (c *RBACV1Alpha1) WatchRoles(ctx context.Context, namespace string, options ...Option) (*RBACV1Alpha1RoleWatcher, error) {
 	url := c.client.urlFor("rbac.authorization.k8s.io", "v1alpha1", namespace, "roles", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -6127,7 +6110,7 @@ func (c *RBACV1Alpha1) CreateRoleBinding(ctx context.Context, obj *rbacv1alpha1.
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -6217,7 +6200,7 @@ func (w *RBACV1Alpha1RoleBindingWatcher) Close() error {
 
 func (c *RBACV1Alpha1) WatchRoleBindings(ctx context.Context, namespace string, options ...Option) (*RBACV1Alpha1RoleBindingWatcher, error) {
 	url := c.client.urlFor("rbac.authorization.k8s.io", "v1alpha1", namespace, "rolebindings", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -6232,7 +6215,6 @@ func (c *RBACV1Alpha1) ListRoleBindings(ctx context.Context, namespace string, o
 	}
 	return resp, nil
 }
-
 
 // RBACV1Beta1 returns a client for interacting with the rbac.authorization.k8s.io/v1beta1 API group.
 func (c *Client) RBACV1Beta1() *RBACV1Beta1 {
@@ -6254,7 +6236,7 @@ func (c *RBACV1Beta1) CreateClusterRole(ctx context.Context, obj *rbacv1beta1.Cl
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !false && ns != ""{
+	if !false && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -6344,7 +6326,7 @@ func (w *RBACV1Beta1ClusterRoleWatcher) Close() error {
 
 func (c *RBACV1Beta1) WatchClusterRoles(ctx context.Context, options ...Option) (*RBACV1Beta1ClusterRoleWatcher, error) {
 	url := c.client.urlFor("rbac.authorization.k8s.io", "v1beta1", AllNamespaces, "clusterroles", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -6370,7 +6352,7 @@ func (c *RBACV1Beta1) CreateClusterRoleBinding(ctx context.Context, obj *rbacv1b
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !false && ns != ""{
+	if !false && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -6460,7 +6442,7 @@ func (w *RBACV1Beta1ClusterRoleBindingWatcher) Close() error {
 
 func (c *RBACV1Beta1) WatchClusterRoleBindings(ctx context.Context, options ...Option) (*RBACV1Beta1ClusterRoleBindingWatcher, error) {
 	url := c.client.urlFor("rbac.authorization.k8s.io", "v1beta1", AllNamespaces, "clusterrolebindings", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -6486,7 +6468,7 @@ func (c *RBACV1Beta1) CreateRole(ctx context.Context, obj *rbacv1beta1.Role) (*r
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -6576,7 +6558,7 @@ func (w *RBACV1Beta1RoleWatcher) Close() error {
 
 func (c *RBACV1Beta1) WatchRoles(ctx context.Context, namespace string, options ...Option) (*RBACV1Beta1RoleWatcher, error) {
 	url := c.client.urlFor("rbac.authorization.k8s.io", "v1beta1", namespace, "roles", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -6602,7 +6584,7 @@ func (c *RBACV1Beta1) CreateRoleBinding(ctx context.Context, obj *rbacv1beta1.Ro
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -6692,7 +6674,7 @@ func (w *RBACV1Beta1RoleBindingWatcher) Close() error {
 
 func (c *RBACV1Beta1) WatchRoleBindings(ctx context.Context, namespace string, options ...Option) (*RBACV1Beta1RoleBindingWatcher, error) {
 	url := c.client.urlFor("rbac.authorization.k8s.io", "v1beta1", namespace, "rolebindings", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -6707,7 +6689,6 @@ func (c *RBACV1Beta1) ListRoleBindings(ctx context.Context, namespace string, op
 	}
 	return resp, nil
 }
-
 
 // SettingsV1Alpha1 returns a client for interacting with the settings/v1alpha1 API group.
 func (c *Client) SettingsV1Alpha1() *SettingsV1Alpha1 {
@@ -6729,7 +6710,7 @@ func (c *SettingsV1Alpha1) CreatePodPreset(ctx context.Context, obj *settingsv1a
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !true && ns != ""{
+	if !true && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -6819,7 +6800,7 @@ func (w *SettingsV1Alpha1PodPresetWatcher) Close() error {
 
 func (c *SettingsV1Alpha1) WatchPodPresets(ctx context.Context, namespace string, options ...Option) (*SettingsV1Alpha1PodPresetWatcher, error) {
 	url := c.client.urlFor("settings", "v1alpha1", namespace, "podpresets", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -6834,7 +6815,6 @@ func (c *SettingsV1Alpha1) ListPodPresets(ctx context.Context, namespace string,
 	}
 	return resp, nil
 }
-
 
 // StorageV1 returns a client for interacting with the storage.k8s.io/v1 API group.
 func (c *Client) StorageV1() *StorageV1 {
@@ -6856,7 +6836,7 @@ func (c *StorageV1) CreateStorageClass(ctx context.Context, obj *storagev1.Stora
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !false && ns != ""{
+	if !false && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -6946,7 +6926,7 @@ func (w *StorageV1StorageClassWatcher) Close() error {
 
 func (c *StorageV1) WatchStorageClasses(ctx context.Context, options ...Option) (*StorageV1StorageClassWatcher, error) {
 	url := c.client.urlFor("storage.k8s.io", "v1", AllNamespaces, "storageclasses", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -6961,7 +6941,6 @@ func (c *StorageV1) ListStorageClasses(ctx context.Context, options ...Option) (
 	}
 	return resp, nil
 }
-
 
 // StorageV1Beta1 returns a client for interacting with the storage.k8s.io/v1beta1 API group.
 func (c *Client) StorageV1Beta1() *StorageV1Beta1 {
@@ -6983,7 +6962,7 @@ func (c *StorageV1Beta1) CreateStorageClass(ctx context.Context, obj *storagev1b
 	if md.Namespace != nil {
 		ns = *md.Namespace
 	}
-	if !false && ns != ""{
+	if !false && ns != "" {
 		return nil, fmt.Errorf("resource isn't namespaced")
 	}
 
@@ -7073,7 +7052,7 @@ func (w *StorageV1Beta1StorageClassWatcher) Close() error {
 
 func (c *StorageV1Beta1) WatchStorageClasses(ctx context.Context, options ...Option) (*StorageV1Beta1StorageClassWatcher, error) {
 	url := c.client.urlFor("storage.k8s.io", "v1beta1", AllNamespaces, "storageclasses", "", options...)
-	watcher, err := c.client.watch(ctx, url)
+	watcher, err := c.client.watch(ctx, pbCodec, url)
 	if err != nil {
 		return nil, err
 	}
@@ -7088,4 +7067,3 @@ func (c *StorageV1Beta1) ListStorageClasses(ctx context.Context, options ...Opti
 	}
 	return resp, nil
 }
-


### PR DESCRIPTION
Fixes issue https://github.com/ericchiang/k8s/issues/62. Because custom resources do not use protobuf, the codec in the watcher needed to be made configurable.