### PR TITLE
*: fix deserialization of JSON errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ test-examples:
 generate: _output/kubernetes _output/bin/protoc _output/bin/gomvpkg _output/bin/protoc-gen-gofast _output/src/github.com/golang/protobuf
 	./scripts/generate.sh
 	go run scripts/register.go
-	cp scripts/time.go.partial apis/meta/v1/time.go
+	cp scripts/json.go.partial apis/meta/v1/json.go
 
 .PHONY: verify-generate
 verify-generate: generate

--- a/apis/meta/v1/json.go
+++ b/apis/meta/v1/json.go
@@ -5,8 +5,9 @@ import (
 	"time"
 )
 
-// JSON marshaling logic for the Time type. Need to make
-// third party resources JSON work.
+// JSON marshaling logic for the Time type so it can be used for custom
+// resources, which serialize to JSON.
+
 func (t Time) MarshalJSON() ([]byte, error) {
 	var seconds, nanos int64
 	if t.Seconds != nil {
@@ -27,5 +28,21 @@ func (t *Time) UnmarshalJSON(p []byte) error {
 	nanos := int32(t1.UnixNano())
 	t.Seconds = &seconds
 	t.Nanos = &nanos
+	return nil
+}
+
+// Status must implement json.Unmarshaler for the codec to deserialize a JSON
+// payload into it.
+//
+// See https://github.com/ericchiang/k8s/issues/82
+
+type jsonStatus Status
+
+func (s *Status) UnmarshalJSON(data []byte) error {
+	var j jsonStatus
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	*s = Status(j)
 	return nil
 }

--- a/client_test.go
+++ b/client_test.go
@@ -210,6 +210,26 @@ func Test404(t *testing.T) {
 	})
 }
 
+func Test404JSON(t *testing.T) {
+	withNamespace(t, func(client *k8s.Client, namespace string) {
+		// Use a JSON object to ensure JSON payload errors deserialize correctly.
+		var configMap configMapJSON
+		err := client.Get(context.TODO(), namespace, "i-dont-exist", &configMap)
+		if err == nil {
+			t.Errorf("expected 404 error")
+			return
+		}
+		apiErr, ok := err.(*k8s.APIError)
+		if !ok {
+			t.Errorf("error was not of type APIError: %T %v", err, err)
+			return
+		}
+		if apiErr.Code != 404 {
+			t.Errorf("expected 404 error code, got %d", apiErr.Code)
+		}
+	})
+}
+
 func TestLabelSelector(t *testing.T) {
 	withNamespace(t, func(client *k8s.Client, namespace string) {
 		for i := 0; i < 5; i++ {

--- a/codec.go
+++ b/codec.go
@@ -48,7 +48,7 @@ func unmarshal(data []byte, contentType string, i interface{}) error {
 		// only decode into JSON of a protobuf message if the type
 		// explicitly implements json.Unmarshaler
 		if _, ok := i.(json.Unmarshaler); !ok {
-			return errors.New("cannot decode json payload into protobuf object")
+			return fmt.Errorf("cannot decode json payload into protobuf object %T", i)
 		}
 	}
 	if err := json.Unmarshal(data, i); err != nil {

--- a/scripts/json.go.partial
+++ b/scripts/json.go.partial
@@ -5,8 +5,9 @@ import (
 	"time"
 )
 
-// JSON marshaling logic for the Time type. Need to make
-// third party resources JSON work.
+// JSON marshaling logic for the Time type so it can be used for custom
+// resources, which serialize to JSON.
+
 func (t Time) MarshalJSON() ([]byte, error) {
 	var seconds, nanos int64
 	if t.Seconds != nil {
@@ -27,5 +28,21 @@ func (t *Time) UnmarshalJSON(p []byte) error {
 	nanos := int32(t1.UnixNano())
 	t.Seconds = &seconds
 	t.Nanos = &nanos
+	return nil
+}
+
+// Status must implement json.Unmarshaler for the codec to deserialize a JSON
+// payload into it.
+//
+// See https://github.com/ericchiang/k8s/issues/82
+
+type jsonStatus Status
+
+func (s *Status) UnmarshalJSON(data []byte) error {
+	var j jsonStatus
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	*s = Status(j)
 	return nil
 }


### PR DESCRIPTION
Have meta/v1.Status implement json decoding to support JSON encoded
errors from the API. This package's decoding logic won't unmarshal
a JSON payload into a protobuf message to prevent silent errors.
Protobuf types can allow JSON by implementing json.Unmarshaler.

Fixes https://github.com/ericchiang/k8s/issues/82