### PR TITLE
fix pluralization for resources ending in 's', and 'y'

### DIFF
--- a/apis/policy/v1beta1/register.go
+++ b/apis/policy/v1beta1/register.go
@@ -4,8 +4,8 @@ import "github.com/ericchiang/k8s"
 
 func init() {
 	k8s.Register("policy", "v1beta1", "poddisruptionbudgets", true, &PodDisruptionBudget{})
-	k8s.Register("policy", "v1beta1", "podsecuritypolicys", false, &PodSecurityPolicy{})
+	k8s.Register("policy", "v1beta1", "podsecuritypolicies", false, &PodSecurityPolicy{})
 
 	k8s.RegisterList("policy", "v1beta1", "poddisruptionbudgets", true, &PodDisruptionBudgetList{})
-	k8s.RegisterList("policy", "v1beta1", "podsecuritypolicys", false, &PodSecurityPolicyList{})
+	k8s.RegisterList("policy", "v1beta1", "podsecuritypolicies", false, &PodSecurityPolicyList{})
 }

--- a/apis/scheduling/v1alpha1/register.go
+++ b/apis/scheduling/v1alpha1/register.go
@@ -3,7 +3,7 @@ package v1alpha1
 import "github.com/ericchiang/k8s"
 
 func init() {
-	k8s.Register("scheduling.k8s.io", "v1alpha1", "priorityclasss", false, &PriorityClass{})
+	k8s.Register("scheduling.k8s.io", "v1alpha1", "priorityclasses", false, &PriorityClass{})
 
-	k8s.RegisterList("scheduling.k8s.io", "v1alpha1", "priorityclasss", false, &PriorityClassList{})
+	k8s.RegisterList("scheduling.k8s.io", "v1alpha1", "priorityclasses", false, &PriorityClassList{})
 }

--- a/apis/storage/v1/register.go
+++ b/apis/storage/v1/register.go
@@ -3,7 +3,7 @@ package v1
 import "github.com/ericchiang/k8s"
 
 func init() {
-	k8s.Register("storage.k8s.io", "v1", "storageclasss", false, &StorageClass{})
+	k8s.Register("storage.k8s.io", "v1", "storageclasses", false, &StorageClass{})
 
-	k8s.RegisterList("storage.k8s.io", "v1", "storageclasss", false, &StorageClassList{})
+	k8s.RegisterList("storage.k8s.io", "v1", "storageclasses", false, &StorageClassList{})
 }

--- a/apis/storage/v1beta1/register.go
+++ b/apis/storage/v1beta1/register.go
@@ -3,7 +3,7 @@ package v1beta1
 import "github.com/ericchiang/k8s"
 
 func init() {
-	k8s.Register("storage.k8s.io", "v1beta1", "storageclasss", false, &StorageClass{})
+	k8s.Register("storage.k8s.io", "v1beta1", "storageclasses", false, &StorageClass{})
 
-	k8s.RegisterList("storage.k8s.io", "v1beta1", "storageclasss", false, &StorageClassList{})
+	k8s.RegisterList("storage.k8s.io", "v1beta1", "storageclasses", false, &StorageClassList{})
 }

--- a/scripts/register.go
+++ b/scripts/register.go
@@ -232,7 +232,7 @@ var apiGroups = []APIGroup{
 		Versions: map[string][]Resource{
 			"v1beta1": []Resource{
 				{"PodDisruptionBudget", "", 0},
-				{"PodSecurityPolicy", "", NotNamespaced},
+				{"PodSecurityPolicy", "podsecuritypolicies", NotNamespaced},
 			},
 		},
 	},
@@ -265,7 +265,7 @@ var apiGroups = []APIGroup{
 		Group:   "scheduling.k8s.io",
 		Versions: map[string][]Resource{
 			"v1alpha1": []Resource{
-				{"PriorityClass", "", NotNamespaced},
+				{"PriorityClass", "priorityclasses", NotNamespaced},
 			},
 		},
 	},
@@ -283,10 +283,10 @@ var apiGroups = []APIGroup{
 		Group:   "storage.k8s.io",
 		Versions: map[string][]Resource{
 			"v1": []Resource{
-				{"StorageClass", "", NotNamespaced},
+				{"StorageClass", "storageclasses", NotNamespaced},
 			},
 			"v1beta1": []Resource{
-				{"StorageClass", "", NotNamespaced},
+				{"StorageClass", "storageclasses", NotNamespaced},
 			},
 			"v1alpha1": []Resource{
 				{"VolumeAttachment", "", NotNamespaced},


### PR DESCRIPTION
Some of the pluralizations were wrong, fixed them and verified it with the upstream swagger.json