### PR TITLE
Build in-cluster url using net/url

### DIFF
--- a/client.go
+++ b/client.go
@@ -36,6 +36,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"time"
 
@@ -221,8 +222,12 @@ func NewInClusterClient() (*Client, error) {
 		return nil, err
 	}
 
+	server := url.URL{
+		Scheme: "https",
+		Host:   net.JoinHostPort(host, port),
+	}
 	cluster := Cluster{
-		Server:               "https://" + host + ":" + port,
+		Server:               server.String(),
 		CertificateAuthority: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
 	}
 	user := AuthInfo{TokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"}


### PR DESCRIPTION
In-cluster server url is built concatenating host and port, this can be problematic with IPv6.

Use `url.URL` and `net.JoinHostPort` to generate the server URL.