### PR TITLE
Fix problems with Watcher (typo, Type="ERROR" events)

### DIFF
--- a/watch.go
+++ b/watch.go
@@ -61,7 +61,7 @@ func (w *watcherJSON) Next(r Resource) (string, error) {
 		return "", fmt.Errorf("decode event: %v", err)
 	}
 	if event.Type == "" {
-		return "", errors.New("wwatch event had no type field")
+		return "", errors.New("watch event had no type field")
 	}
 	if err := json.Unmarshal([]byte(event.Object), r); err != nil {
 		return "", fmt.Errorf("decode resource: %v", err)


### PR DESCRIPTION
 - (minor) Fix a typo in an error message
 - (major) Correctly handle `.Type=&"ERROR"` watch events as `APIError`s, instead of trying to protobuf decode the wrong type.